### PR TITLE
Enable Code Coverage Report

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Next: Chrome",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Next: Node",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/next",
+            "env": {
+                "NODE_OPTIONS": "--inspect"
+            },
+            "port": 9229,
+            "console": "integratedTerminal"
+        },
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Next: Full",
+            "configurations": ["Next: Node", "Next: Chrome"]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "jest.pathToJest": "npm run test --",
+    "coverage-gutters.showGutterCoverage": false,
+    "coverage-gutters.showLineCoverage": true
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "!**/node_modules/**",
       "!**/vendor/**"
     ],
+    "coverageReporters": [
+      "lcov",
+      "cobertura"
+    ],
     "setupFilesAfterEnv": [
       "jest-enzyme"
     ],


### PR DESCRIPTION
The build of this is to enable code coverage reporting in the Azure pipeline. The commit also places .vscode configurations for easy use.